### PR TITLE
Add History Entity

### DIFF
--- a/src/constant/Constants.ts
+++ b/src/constant/Constants.ts
@@ -1,5 +1,4 @@
 export const DIR_PATH_UPLOADED_IMAGE = `${__dirname}/temp/image/`;
-
 export const RESPONSE_MESSAGE = {
     OK: {'msg':'ok'},
     SERVER_ERROR: {'msg':'server_error'},
@@ -12,4 +11,9 @@ export const RESPONSE_MESSAGE = {
     WRONG_INFO: {'msg': 'wrong_information_error'},
     WRONG_REQ: {'msg': 'wrong_request_error'},
     REG_NOT_FOUND: {'msg': 'region_not_found'}
+};
+
+export const DEFAULT_PATH = {
+    INPUT : '/',
+    OUTPUT : '/'
 };

--- a/src/controller/HistoryController.ts
+++ b/src/controller/HistoryController.ts
@@ -1,0 +1,9 @@
+import {BaseController} from './interfaces/BaseController';
+import {History} from '../entities/History';
+import {DataSource} from 'typeorm';
+
+export class HistoryController extends BaseController<History> {
+    constructor(source: DataSource) {
+        super(source, History);
+    }
+}

--- a/src/entities/History.ts
+++ b/src/entities/History.ts
@@ -1,4 +1,4 @@
-import {Column, Entity, JoinColumn, OneToMany} from 'typeorm';
+import {Column, Entity, JoinColumn, ManyToOne } from 'typeorm';
 import {Common} from './interfaces/Common';
 import {Model} from './Model';
 import {User} from './User';
@@ -10,18 +10,17 @@ export class History extends Common {
         inputPath: string;
     @Column()
         outputPath: string;
-    @OneToMany(
+    @ManyToOne(
         () => User,
         (user) => user.id
     )
     @JoinColumn()
         register: User;
 
-    @OneToMany(
+    @ManyToOne(
         () => Model,
         (model) => model.id
     )
     @JoinColumn()
-        model: Model;
-
+    targetModel: Model;
 }

--- a/src/entities/History.ts
+++ b/src/entities/History.ts
@@ -22,5 +22,5 @@ export class History extends Common {
         (model) => model.id
     )
     @JoinColumn()
-    targetModel: Model;
+        targetModel: Model;
 }

--- a/src/entities/History.ts
+++ b/src/entities/History.ts
@@ -1,0 +1,27 @@
+import {Column, Entity, JoinColumn, OneToMany} from 'typeorm';
+import {Common} from './interfaces/Common';
+import {Model} from './Model';
+import {User} from './User';
+
+// ubuntu:latest
+@Entity()
+export class History extends Common {
+    @Column()
+        inputPath: string;
+    @Column()
+        outputPath: string;
+    @OneToMany(
+        () => User,
+        (user) => user.id
+    )
+    @JoinColumn()
+        register: User;
+
+    @OneToMany(
+        () => Model,
+        (model) => model.id
+    )
+    @JoinColumn()
+        model: Model;
+
+}


### PR DESCRIPTION
# Description
실행한 정보를 저장하는 `History`의 `TypeORM Entity`와 관련된 내용이다.
## attribute
- inputPath
  - 입력된 데이터가 저장되는 경로
- outputPath
  - 출력된 결과가 저장되는 경로
- targetModelId(FK)
   - 실행된 모델 id
- registerId(FK)
  - 실행한 사용자 id
- default
  - createdTime
  - updatedTime
  - id